### PR TITLE
 phoenix#setup before phoenix#setup_projections

### DIFF
--- a/plugin/phoenix.vim
+++ b/plugin/phoenix.vim
@@ -24,6 +24,7 @@ augroup END
 
 augroup phoenix_projections
   autocmd!
+  autocmd User ProjectionistDetect call phoenix#setup()
   autocmd User ProjectionistDetect call phoenix#setup_projections()
 augroup END
 


### PR DESCRIPTION
We cannot always assume that setup_projections is being called after
phoenix has already setup the buffer.

Closes #4